### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
-    @item = Item.all.order('created_at DESC')
+    @item = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
+    @item = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
     validates :image
     validates :name,        length: { maximum: 40 }
     validates :description, length: { maximum: 1000 }
-    validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
+    validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
 
     with_options numericality: { only_integer: true, other_than: 1 } do
       validates :category_id

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,56 +126,54 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @item.each do |item|%>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.postage_type.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @item == nil %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Item, type: :model do
     it 'userが存在しないと登録できない' do
       @item.user = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("User must exist")
+      expect(@item.errors.full_messages).to include('User must exist')
     end
 
     it '商品画像を1枚つけなければ、商品の出品ができない' do
@@ -151,7 +151,7 @@ RSpec.describe Item, type: :model do
     end
 
     it '価格が、¥9,999,999より大きい額では商品の出品ができない' do
-      @item.price = 39999999
+      @item.price = 39_999_999
       @item.valid?
       expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
     end


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
商品一覧表示機能の実装のため

## 機能実装の様子

```
- 出品した商品の一覧表示ができていること
- 上から、出品された日時が新しい順に表示されること
- 画像/価格/商品名の3つの情報について表示できていること
- 画像が表示されており、画像がリンク切れなどになっていないこと
```
[実装の様子1](https://i.gyazo.com/b64d5fd7a53f7dea0f9248b07a5ff1be.gif)
<a href="https://gyazo.com/b64d5fd7a53f7dea0f9248b07a5ff1be"><img src="https://i.gyazo.com/b64d5fd7a53f7dea0f9248b07a5ff1be.gif" alt="Image from Gyazo" width="800"/></a>

`- ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること`

[実装の様子2](https://gyazo.com/5a02c55ab661961dca834f12e1a3eef9)

<a href="https://gyazo.com/5a02c55ab661961dca834f12e1a3eef9"><img src="https://i.gyazo.com/5a02c55ab661961dca834f12e1a3eef9.gif" alt="Image from Gyazo" width="800"/></a>

なお、下記は現段階では未実装でございます。

`- 売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること`

### （参考）商品情報が記載されたDB

[参考](https://gyazo.com/ac3cb3286c8add4b55b6f5884f0e88a0)
<a href="https://gyazo.com/ac3cb3286c8add4b55b6f5884f0e88a0"><img src="https://i.gyazo.com/ac3cb3286c8add4b55b6f5884f0e88a0.png" alt="Image from Gyazo" width=“800”/></a>